### PR TITLE
Message.create_with_recipients : No longer accept :recipient_member_usernames (only ids)

### DIFF
--- a/lib/libertree/model/message.rb
+++ b/lib/libertree/model/message.rb
@@ -39,25 +39,13 @@ module Libertree
         end
       end
 
-      # Pass either :recipient_member_usernames or :recipient_member_ids in args.
       def self.create_with_recipients(args)
         message = self.create(
           sender_member_id: args[:sender_member_id],
           text: args[:text]
         )
 
-        if args[:recipient_member_usernames].nil?
-          recipient_member_ids = Array(args[:recipient_member_ids])
-        else
-          recipient_member_ids = []
-          Array(args[:recipient_member_usernames]).each do |username|
-            account = Account[username: username]
-            if account
-              recipient_member_ids << account.member.id
-            end
-          end
-        end
-
+        recipient_member_ids = Array(args[:recipient_member_ids])
         recipient_member_ids.each do |member_id|
           DB.dbh.i  "INSERT INTO message_recipients ( message_id, member_id ) VALUES ( ?, ? )", message.id, member_id.to_i
           m = Member[member_id]


### PR DESCRIPTION
See also:

https://github.com/Libertree/libertree/pull/8
https://github.com/Libertree/libertree-client-rb/pull/2
https://github.com/Libertree/libertree-backend-rb/pull/5
https://github.com/Libertree/libertree-frontend-ramaze/pull/31
