### PR TITLE
replace YAML parser syck with psych

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'http://rubygems.org'
 gem 'm4dbi' #, :git => 'git://github.com/Pistos/m4dbi.git', :branch => 'fix-memory-leaks'
 gem 'rdbi', :git => 'git://github.com/RDBI/rdbi.git', :ref => 'pre-sth-leak'
 gem 'rdbi-driver-postgresql' #, :git => 'git://github.com/RDBI/rdbi-driver-postgresql.git'
-gem 'syck', :platforms => [:ruby_20]
 gem 'ruby-oembed'
 gem 'json'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,6 @@ GEM
     ruby-oembed (0.8.8)
     ruby_core_source (0.1.5)
       archive-tar-minitar (>= 0.5.2)
-    syck (1.0.0)
     typelib (0.1.0)
 
 PLATFORMS
@@ -88,4 +87,3 @@ DEPENDENCIES
   ruby-debug-base19x (~> 0.11.30.pre4)
   ruby-debug19
   ruby-oembed
-  syck

--- a/lib/libertree/db.rb
+++ b/lib/libertree/db.rb
@@ -1,6 +1,6 @@
 require 'm4dbi'
 require 'rdbi-driver-postgresql'
-require 'syck'
+require 'yaml'
 
 module Libertree
   module DB
@@ -14,7 +14,7 @@ module Libertree
 
     def self.load_config(filename)
       config_file = filename
-      configs ||= Syck.load( IO.read(config_file) )
+      configs ||= YAML.load( IO.read(config_file) )
       env = ENV['LIBERTREE_ENV'] || 'development'
       @config = configs[env]
     end


### PR DESCRIPTION
The YAML parser syck is no longer supported, so let's use the default psych.
